### PR TITLE
bump subleveldown

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "routes-router": "^4.1.1",
     "run-series": "^1.0.2",
     "st": "^0.5.2",
-    "subleveldown": "^1.0.6"
+    "subleveldown": "^2.0.0"
   },
   "devDependencies": {
     "autoless": "^0.1.5",


### PR DESCRIPTION
made a breaking change to subleveldown in the way it handles sublevels in sublevels (it tried to be clever about it before - now it doesn't). might as well bump here now :)

remember to `npm install` afterward merging this